### PR TITLE
fix(js): enforce MIME type

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Javascript Test</title>
   </head>
 
@@ -8,5 +10,5 @@
     <button id="connectButton">Connect</button>
     <button id="executeButton">Execute</button>
   </body>
-  <script src="./index.js" type="module"></script>
+  <script type="text/javascript" src="./index.js" type="module"></script>
 </html>


### PR DESCRIPTION
error in console: "Failed To Load Module Script: Expected A Javascript Module Script But The Server Responded With A Mime Type Of “text/plain”. Strict Mime Type Checking Is Enforced For Module Scripts Per Html Spec"

 This fixes this issue